### PR TITLE
Add FastAPI backend for GGUF model serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # local_gpu_batch
+
 Local LLM batch process
+
+## Backend
+
+Build the FastAPI backend and run it with the model directory mounted:
+
+```bash
+docker build -t local-backend backend
+docker run -v $(pwd)/models:/models -p 8000:8000 local-backend
+```
+
+Place your GGUF model file inside the `models/` directory. The server exposes a POST `/generate` endpoint that accepts a JSON body with a `prompt` field and returns generated text.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir fastapi uvicorn[standard] llama-cpp-python
+
+WORKDIR /app
+COPY main.py .
+
+VOLUME ["/models"]
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from llama_cpp import Llama
+import os
+
+MODEL_PATH = os.environ.get("MODEL_PATH", "/models/model.gguf")
+llm = Llama(model_path=MODEL_PATH)
+
+app = FastAPI()
+
+class GenerateRequest(BaseModel):
+    prompt: str
+
+@app.post("/generate")
+def generate(req: GenerateRequest):
+    """Generate text for a given prompt using the loaded model."""
+    result = llm.create_completion(prompt=req.prompt)
+    text = result["choices"][0]["text"]
+    return {"text": text}


### PR DESCRIPTION
## Summary
- add backend directory with FastAPI app that loads a GGUF model via llama-cpp-python
- include Dockerfile installing fastapi, uvicorn and llama-cpp-python, exposing port 8000 and mounting /models
- document how to build and run the backend with a mounted models/ directory

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688fc1d2eda88320964dd12a6d5cecc0