### PR TITLE
Add Makefile for docker compose and model management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Models downloaded at runtime
+models/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: build up down pull-models clean
+
+build:
+	docker-compose build
+
+up:
+	docker-compose up -d
+
+down:
+	docker-compose down
+
+pull-models:
+	./scripts/pull_models.sh
+
+clean:
+	docker-compose down --volumes --remove-orphans
+	docker system prune -f

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # local_gpu_batch
 Local LLM batch process
+
+## Usage
+
+Convenience commands are provided via the `Makefile`:
+
+- `make build` – build Docker images
+- `make up` – start services in the background
+- `make down` – stop and remove containers
+- `make pull-models` – download model weights (uses `huggingface-cli` and writes to `models/`)
+- `make clean` – remove containers and prune unused Docker data
+
+Set the `MODELS` environment variable to control which Hugging Face models are fetched when running `make pull-models`.

--- a/scripts/pull_models.sh
+++ b/scripts/pull_models.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODELS=${MODELS:-"sshleifer/tiny-gpt2"}
+MODEL_DIR=${MODEL_DIR:-"models"}
+
+mkdir -p "$MODEL_DIR"
+
+for model in $MODELS; do
+    echo "Pulling $model..."
+    huggingface-cli download "$model" --local-dir "$MODEL_DIR/${model##*/}" --local-dir-use-symlinks False
+done
+


### PR DESCRIPTION
## Summary
- add Makefile with docker-compose targets for build, up, down, model pulls, and cleanup
- add script to download models and ignore generated model files
- document Makefile usage in README

## Testing
- `bash -n scripts/pull_models.sh`
- `make -n build up down pull-models clean`


------
https://chatgpt.com/codex/tasks/task_e_688fc1d826ac8320be8858aedc3ab3e0